### PR TITLE
reset version to 2.0.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ node('ibm-jenkins-slave-nvm') {
 
   pipeline.setup(
     packageName : 'org.zowe.smpe',
-    version     : '1.3.5',
+    version     : '2.0.0',
     github: [
       email                      : lib.Constants.DEFAULT_GITHUB_ROBOT_EMAIL,
       usernamePasswordCredential : lib.Constants.DEFAULT_GITHUB_ROBOT_CREDENTIAL,

--- a/artifactory-download-spec.json.template
+++ b/artifactory-download-spec.json.template
@@ -1,7 +1,7 @@
 {
   "files": [{
       "pattern": "libs-snapshot-local/org/zowe/1.3.0-STAGING/zowe-1.3.*.pax",
-      "target": ".pax/zowe-1.3.5.pax",
+      "target": ".pax/",
       "flat": "true",
        "sortBy": ["created"],
       "sortOrder": "desc",
@@ -9,7 +9,7 @@
     },
     {
       "pattern": "libs-release-local/org/zowe/1.3.*/zowe-cli-package-1.3.*.zip",
-      "target": ".pax/zowe-cli-package-1.3.*.zip",
+      "target": ".pax/",
       "flat": "true",
       "sortBy": ["created"],
       "sortOrder": "desc",


### PR DESCRIPTION
Not sure 2.0.0 is valid or not.

After 1.4 released, we can change to pick from `1.4.0-STAGING`.