### PR TITLE
fix zowe install on interactive mode

### DIFF
--- a/.pax/post-packaging.sh
+++ b/.pax/post-packaging.sh
@@ -59,7 +59,7 @@ echo "$FUNC content of ${INPUT_TXT}:"
 cat "${INPUT_TXT}"
 mkdir -p zowe
 
-./bld/smpe.sh -i "${CURR_PWD}/${INPUT_TXT}" -v ${FMID_VERISON} -r "${CURR_PWD}/zowe"
+./bld/smpe.sh -i "${CURR_PWD}/${INPUT_TXT}" -v ${FMID_VERISON} -r "${CURR_PWD}/zowe" -d
 
 # get the final build result
 ZOWE_SMPE_PAX="${CURR_PWD}/zowe/AZWE${FMID_VERISON}/gimzip/AZWE${FMID_VERISON}.pax.Z"

--- a/smpe/bld/smpe-install.sh
+++ b/smpe/bld/smpe-install.sh
@@ -169,7 +169,7 @@ opts="$opts -I"                                # Install only - no config
 #opts="$opts -i $stage"                         # target directory
 #opts="$opts -h $mvsI"                          # target HLQ
 #opts="$opts -f $log/$logFile"                  # install log
-_cmd $extract/$prodScript $opts
+_cmd sh -c "$extract/$prodScript $opts"
 
 #For debug
 ls -al $stage

--- a/smpe/bld/smpe-install.sh
+++ b/smpe/bld/smpe-install.sh
@@ -177,7 +177,7 @@ rm -fr ~/.zowe_profile_smpe_packaging_backup
 if [ -f "~/.zowe_profile" ]; then
   mv ~/.zowe_profile ~/.zowe_profile_smpe_packaging_backup
 fi
-_cmd sh -c "$extract/$prodScript $opts"
+_cmd sh -c "$extract/$prodScript $opts" </dev/null
 if [ -f "~/.zowe_profile_smpe_packaging_backup" ]; then
   mv ~/.zowe_profile_smpe_packaging_backup ~/.zowe_profile
 fi

--- a/smpe/bld/smpe-install.sh
+++ b/smpe/bld/smpe-install.sh
@@ -169,7 +169,18 @@ opts="$opts -I"                                # Install only - no config
 #opts="$opts -i $stage"                         # target directory
 #opts="$opts -h $mvsI"                          # target HLQ
 #opts="$opts -f $log/$logFile"                  # install log
+# FIXME: since the installation will update .zowe_profile, to avoid affecting
+#        existing installation of Zowe, we backup .zowe_profile and restore
+#        later. - jack
+# Question, if the installation failed and exit, will the backup be restored?
+rm -fr ~/.zowe_profile_smpe_packaging_backup
+if [ -f "~/.zowe_profile" ]; then
+  mv ~/.zowe_profile ~/.zowe_profile_smpe_packaging_backup
+fi
 _cmd sh -c "$extract/$prodScript $opts"
+if [ -f "~/.zowe_profile_smpe_packaging_backup" ]; then
+  mv ~/.zowe_profile_smpe_packaging_backup ~/.zowe_profile
+fi
 
 #For debug
 ls -al $stage


### PR DESCRIPTION
There are few issues related running Zowe install script:

1. The install script is running in interactive mode and $PS1 does have value. I compared Linux vs USS, ssh into USS is alway in interactive mode. This is different from Linux.
2. The install script running on smoke test is pushed into background with `&` and use `wait` for the background to finish. So all read input are suppressed in this case.
3. The install script will read and source `~/.zowe_profile`. So if the system had ran a smoke test successfully, it has a good `~/.zowe_profile` and will be used by the smpe packaging build. But if `.zowe_profile` is missing, the smpe packaging will try to read from input.

I tweaked `smpe-install.sh` to redirect `/dev/null` as input during installation, also try to remove `~/.zowe_profile` so the packaging process won't be affected by the smoke test.
