### PR TITLE
Set dsName=auto in the yaml file

### DIFF
--- a/smpe/bld/smpe-install.sh
+++ b/smpe/bld/smpe-install.sh
@@ -155,7 +155,7 @@ test "$alter" && _cmd $alter $debug PROD $extract
 echo "-- Updating yaml file"
 CI_ZOWE_CONFIG_FILE=$extract/install/zowe-install.yaml
 sed -e "/^install:/,\$s#rootDir=.*\$#rootDir=$stage#" \
-  -e "/^zowe-server-proclib:/,\$s#dsName=.*\$#dsName=$auto#" \
+  -e "/^zowe-server-proclib:/,\$s#dsName=.*\$#dsName=auto#" \
   "${CI_ZOWE_CONFIG_FILE}" \
   > "${CI_ZOWE_CONFIG_FILE}.tmp" 
 mv "${CI_ZOWE_CONFIG_FILE}.tmp" "${CI_ZOWE_CONFIG_FILE}"

--- a/smpe/bld/smpe-install.sh
+++ b/smpe/bld/smpe-install.sh
@@ -155,7 +155,7 @@ test "$alter" && _cmd $alter $debug PROD $extract
 echo "-- Updating yaml file"
 CI_ZOWE_CONFIG_FILE=$extract/install/zowe-install.yaml
 sed -e "/^install:/,\$s#rootDir=.*\$#rootDir=$stage#" \
-  -e "/^zowe-server-proclib:/,\$s#dsName=.*\$#dsName=$mvsI.PROCLIB#" \
+  -e "/^zowe-server-proclib:/,\$s#dsName=.*\$#dsName=$auto#" \
   "${CI_ZOWE_CONFIG_FILE}" \
   > "${CI_ZOWE_CONFIG_FILE}.tmp" 
 mv "${CI_ZOWE_CONFIG_FILE}.tmp" "${CI_ZOWE_CONFIG_FILE}"

--- a/smpe/bld/smpe-install.sh
+++ b/smpe/bld/smpe-install.sh
@@ -155,7 +155,6 @@ test "$alter" && _cmd $alter $debug PROD $extract
 echo "-- Updating yaml file"
 CI_ZOWE_CONFIG_FILE=$extract/install/zowe-install.yaml
 sed -e "/^install:/,\$s#rootDir=.*\$#rootDir=$stage#" \
-  -e "/^zowe-server-proclib:/,\$s#dsName=.*\$#dsName=auto#" \
   "${CI_ZOWE_CONFIG_FILE}" \
   > "${CI_ZOWE_CONFIG_FILE}.tmp" 
 mv "${CI_ZOWE_CONFIG_FILE}.tmp" "${CI_ZOWE_CONFIG_FILE}"


### PR DESCRIPTION
`dsName` is set to BLD.AZWE001.BLD.PROCLIB, which does not exist and is not in the JES2 concatenation.  Setting `dsName=auto` allows the install to choose a valid dataset.